### PR TITLE
More information about default value for user

### DIFF
--- a/lib/highline/question.rb
+++ b/lib/highline/question.rb
@@ -576,13 +576,13 @@ class HighLine
     #
     def append_default
       if template =~ /([\t ]+)\Z/
-        template << "|#{default}|#{$1}"
+        template << "|Default value: #{default}|#{$1}"
       elsif template == ""
-        template << "|#{default}|  "
+        template << "|Default value: #{default}|  "
       elsif template[-1, 1] == "\n"
-        template[-2, 0] =  "  |#{default}|"
+        template[-2, 0] =  "  |Default value: #{default}|"
       else
-        template << "  |#{default}|"
+        template << "  |Default value: #{default}|"
       end
     end
 


### PR DESCRIPTION
Indicate default value for the user on the output.  The user is presented by only |value|, which is in, my opinion, not enough.  The user should now that there is a default value waiting for him.  User should be prompted by something like: |Default value: value|
